### PR TITLE
fix: delete pop scope logic on screen_main_tabs

### DIFF
--- a/notiskku/lib/screen/screen_intro_ready.dart
+++ b/notiskku/lib/screen/screen_intro_ready.dart
@@ -49,12 +49,13 @@ class ScreenIntroReady extends StatelessWidget {
                 child: WideGreen(
                   text: '나의 공지 보러가기',
                   onPressed: () async {
+                    // isFirstLaunch 플래그 저장
                     await AppPreferences.setFirstLaunch();
-                    Navigator.pushReplacement(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => const ScreenMainTabs(),
-                      ),
+
+                    // !! 온보딩 이전에 쌓여 있던 모든 라우트 제거
+                    Navigator.of(context).pushAndRemoveUntil(
+                      MaterialPageRoute(builder: (_) => const ScreenMainTabs()),
+                      (route) => false, // <- 스택에 있는 모든 route를 제거함
                     );
                   },
                 ),

--- a/notiskku/lib/screen/screen_main_tabs.dart
+++ b/notiskku/lib/screen/screen_main_tabs.dart
@@ -115,23 +115,20 @@ class _ScreenMainTabsState extends ConsumerState<ScreenMainTabs> {
     final scheme = theme.colorScheme;
     final currentIndex = ref.watch(tabIndexProvider);
 
-    return PopScope(
-      canPop: false, // 뒤로가기 차단
-      child: Scaffold(
-        body: _pages[currentIndex],
-        bottomNavigationBar: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 5),
-          child: BottomNavigationBar(
-            type: BottomNavigationBarType.fixed,
-            elevation: 0,
-            items: _navItems,
-            currentIndex: currentIndex,
-            selectedItemColor: scheme.primary,
-            unselectedItemColor: scheme.outline,
-            selectedFontSize: 11.sp,
-            unselectedFontSize: 11.sp,
-            onTap: _onItemTapped,
-          ),
+    return Scaffold(
+      body: _pages[currentIndex],
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 5),
+        child: BottomNavigationBar(
+          type: BottomNavigationBarType.fixed,
+          elevation: 0,
+          items: _navItems,
+          currentIndex: currentIndex,
+          selectedItemColor: scheme.primary,
+          unselectedItemColor: scheme.outline,
+          selectedFontSize: 11.sp,
+          unselectedFontSize: 11.sp,
+          onTap: _onItemTapped,
         ),
       ),
     );


### PR DESCRIPTION
remove stacked route instead of preventing pop(go back) 뒤로가기를 막으면 뒤로가기 통한 앱 종료까지 막히는 이슈 있었음

(related issue #80 )